### PR TITLE
feat: support discard job for sandboxed jobs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chaos-labs/bullmq",
-  "version": "1.87.0",
+  "version": "1.87.1",
   "description": "Queue for messages and jobs based on Redis",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/src/classes/child-processor.ts
+++ b/src/classes/child-processor.ts
@@ -178,5 +178,10 @@ function wrapJob(job: JobJson): SandboxedJob {
         value: row,
       });
     },
+    discard: async () => {
+      childSend(process, {
+        cmd: ParentCommand.Discard,
+      });
+    },
   };
 }

--- a/src/classes/sandbox.ts
+++ b/src/classes/sandbox.ts
@@ -36,6 +36,9 @@ const sandbox = <T, R, N extends string>(
           case ParentCommand.Log:
             await job.log(msg.value);
             break;
+          case ParentCommand.Discard:
+            job.discard();
+            break;
         }
       };
 

--- a/src/interfaces/parent-command.ts
+++ b/src/interfaces/parent-command.ts
@@ -6,4 +6,5 @@ export enum ParentCommand {
   Error,
   Progress,
   Log,
+  Discard,
 }

--- a/src/interfaces/sandboxed-job.ts
+++ b/src/interfaces/sandboxed-job.ts
@@ -14,4 +14,5 @@ export interface SandboxedJob<T = any, R = any>
   updateProgress: (value: object | number) => Promise<void>;
   log: (row: any) => void;
   returnValue: R;
+  discard: () => Promise<void>;
 }


### PR DESCRIPTION
Add support for `Discard()` for sandboxed jobs to mark that no retires are required for the job